### PR TITLE
Add recursive rendering of template partials, allowing template inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,90 @@ gulp.task('default', function(){
 ```
 Now dist will have `template.js` with content as `Follow @gnumanth`
 
+
+## Template inheritance & Partials
+
+Partials will be rendered recursively, allowing for template inheritance.
+
+### Example:
+
+Folder structure
+
+```
+|-- templates
+    |-- page1.hogan
+    |-- page2.hogan
+    |-- partials
+    |   |-- header.hogan
+    |   |-- footer.hogan
+```
+
+page1.hogan
+
+```html
+<h1>Page 1</h1>
+{{> header }}
+{{> footer }}
+```
+
+page2.hogan
+```html
+<h1>Page 2</h1>
+{{> header }}
+{{> footer }}
+```
+
+header.hogan
+```html
+<header>
+    Logo {{#image}}<img>{{/image}}
+</header>
+```
+
+footer.hogan
+```html
+<footer>
+    Copyright {{year}}
+</footer>
+```
+
+gulpfile.js
+
+```javascript
+var hogan = require('gulp-hogan');
+
+gulp.task('default', function(){
+  gulp.src('template/*.hogan', {}, '.html')
+    .pipe(hogan({year: '2016', section: true}, null, '.html'))
+    .pipe(gulp.dest('dist'));
+});
+```
+
+dist/page1.html
+
+```html
+<h1>Page 1</h1>
+<header>
+    Logo <img>
+</header>
+<footer>
+    Copyright 2016
+</footer>
+```
+
+dist/page2.html
+
+```html
+<h1>Page 2</h1>
+<header>
+    Logo <img>
+</header>
+<footer>
+    Copyright 2016
+</footer>
+```
+
+
 [travis-url]: http://travis-ci.org/hemanth/gulp-hogan
 [travis-image]: https://travis-ci.org/hemanth/gulp-hogan.svg
 

--- a/README.md
+++ b/README.md
@@ -39,26 +39,23 @@ Folder structure
 
 ```
 |-- templates
-    |-- page1.hogan
-    |-- page2.hogan
+    |-- page.hogan
+    |-- body.hogan
     |-- partials
     |   |-- header.hogan
     |   |-- footer.hogan
 ```
 
-page1.hogan
-
+page.hogan
 ```html
-<h1>Page 1</h1>
-{{> header }}
-{{> footer }}
+<h1>Page</h1>
+{{> body }}
 ```
 
-page2.hogan
+body.hogan
 ```html
-<h1>Page 2</h1>
-{{> header }}
-{{> footer }}
+{{> partials/header }}
+{{> partials/footer }}
 ```
 
 header.hogan
@@ -81,28 +78,16 @@ gulpfile.js
 var hogan = require('gulp-hogan');
 
 gulp.task('default', function(){
-  gulp.src('template/*.hogan', {}, '.html')
-    .pipe(hogan({year: '2016', section: true}, null, '.html'))
+  gulp.src('template/page.hogan', {}, '.html')
+    .pipe(hogan({year: '2016'}, null, '.html'))
     .pipe(gulp.dest('dist'));
 });
 ```
 
-dist/page1.html
+dist/page.html
 
 ```html
-<h1>Page 1</h1>
-<header>
-    Logo <img>
-</header>
-<footer>
-    Copyright 2016
-</footer>
-```
-
-dist/page2.html
-
-```html
-<h1>Page 2</h1>
+<h1>Page</h1>
 <header>
     Logo <img>
 </header>

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 'use strict';
-const es = require('event-stream');;
-const gutil = require('gulp-util');
-const Hogan = require('hogan.js');
-const path = require('path');
-const fs = require('fs');
+var es = require('event-stream');
+var gutil = require('gulp-util');
+var Hogan = require('hogan.js');
+var path = require('path');
+var fs = require('fs');
 
 module.exports = function(data, options, extension) {
   data = data || {};
   extension = extension || '.js';
   return es.map(function (file, cb) {
-    const compiled = Hogan.compile(file.contents.toString(), options);
-    const partialTemplates = getPartials(compiled, path.dirname(file.path), path.extname(file.path), data, options);
+    var compiled = Hogan.compile(file.contents.toString(), options);
+    var partialTemplates = getPartials(compiled, path.dirname(file.path), path.extname(file.path), data, options);
     
     file.contents = new Buffer( compiled.render(data, partialTemplates) );
     file.path = gutil.replaceExtension(file.path, extension);
@@ -19,13 +19,13 @@ module.exports = function(data, options, extension) {
 };
 
 
-const getPartials = (compiled, dir, ext, data, options) => {
-    let currentPartials = {},
+function getPartials(compiled, dir, ext, data, options) {
+    var currentPartials = {},
         partialTemplates = {},
         partialPath = '',
         compiledPartial;
     
-    Object.keys(compiled.partials).forEach((tag) => {
+    Object.keys(compiled.partials).forEach(function (tag) {
         // find the path of the partial
         partialPath = path.format({
             'dir': dir,

--- a/index.js
+++ b/index.js
@@ -1,15 +1,51 @@
 'use strict';
-var map = require('map-stream');
-var es = require('event-stream');;
-var gutil = require('gulp-util');
-var Hogan = require('hogan.js');
+const es = require('event-stream');;
+const gutil = require('gulp-util');
+const Hogan = require('hogan.js');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = function(data, options, extension) {
   data = data || {};
   extension = extension || '.js';
   return es.map(function (file, cb) {
-    file.contents = new Buffer( Hogan.compile(file.contents.toString(), options).render(data) );
+    const compiled = Hogan.compile(file.contents.toString(), options);
+    const partialTemplates = getPartials(compiled, path.dirname(file.path), path.extname(file.path), data, options);
+    
+    file.contents = new Buffer( compiled.render(data, partialTemplates) );
     file.path = gutil.replaceExtension(file.path, extension);
     cb(null,file);
   });
 };
+
+
+const getPartials = (compiled, dir, ext, data, options) => {
+    let currentPartials = {},
+        partialTemplates = {},
+        partialPath = '',
+        compiledPartial;
+    
+    Object.keys(compiled.partials).forEach((tag) => {
+        // find the path of the partial
+        partialPath = path.format({
+            'dir': dir,
+            'base': compiled.partials[tag].name + ext
+        });
+        
+        
+        // read and compile the files contents
+        compiledPartial = Hogan.compile(fs.readFileSync(partialPath).toString(), options);
+        
+        
+        // if partials exist within the compiled tempalte, then 
+        if (Object.keys(compiledPartial.partials).length !== 0) {
+            currentPartials = getPartials(compiledPartial, dir, ext, data, options);
+        }
+        
+        
+        // Assign the contents of the partial to a key of the same name
+        partialTemplates[compiled.partials[tag].name] = compiledPartial.render(data, currentPartials);
+    });
+    
+    return partialTemplates;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-hogan",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "gulp plugin to compile mustache templates",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,6 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "event-stream": "^3.1.7",
-    "map-stream": "^0.0.6",
     "hogan.js": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This request adds the ability for the plugin to render template partials recursively, effectively enabling template inheritance with very little additional configuration in the gulpfile.  

Template inheritance is currently supported by Hogan.js and is possible to implement within a gulpfile.  However, it requires that you compile files, save them to an object, and then pass that object as an argument to this plugin to render them properly.  The general idea is outlined [here](https://github.com/mustache/spec/pull/75), and the [Hogan tests](https://github.com/twitter/hogan.js/blob/6e6d69c086061341315af4e2c21b0688794f1045/test/index.js#L394-L417) show the way it is currently implemented, i.e. pre-compiling partials and passing as an argument.

The advantage of including this functionality in the plugin is that partials can be added to templates and they will be automatically compiled and rendered at build time with no additional configuration needed.  Any partials that are declared in a template will be fetched automatically and rendered along with the parent.

I could not determine an effective way to test this without generating several mock files (which I did for my own purposes and for the example added to the README).  The lack of testability is the biggest flaw in this request.

This addition is fully functional within my own testing for rendering templates with partials, however, as noted above I have not been able to extensively test it.  I would appreciate any guidance or suggestions on creating a test suite for this addition, or running an [existing spec](https://github.com/mustache/spec/pull/75/commits/ab227509e64961943ca374c09c08b63f59da014a) against it.  Any critique of the code design is also appreciated if something sticks out.
